### PR TITLE
Emulate Webpack's module.id to make eg. react-hot-loader work

### DIFF
--- a/index.js
+++ b/index.js
@@ -274,7 +274,15 @@ module.exports = function(bundle, opts) {
       }
     }
 
-    bundle.pipeline.get('deps').push(through.obj(function(row, enc, next) {
+    var depPipeline = bundle.pipeline.get('deps');
+
+    /* This emulates Webpack's module.id, as needed to make eg. react-hot-loader work. */
+    depPipeline.push(through.obj(function(row, enc, next) {
+      row.source = "module.id = " + JSON.stringify(row.id) + "; " + row.source;
+      next(null, row);
+    }));
+
+    depPipeline.push(through.obj(function(row, enc, next) {
       if (row.file !== hmrManagerFilename) {
         makeModuleMetaEntry(fileKey(row.file));
         _.forOwn(row.deps, function(name, ref) {

--- a/index.js
+++ b/index.js
@@ -278,7 +278,11 @@ module.exports = function(bundle, opts) {
 
     /* This emulates Webpack's module.id, as needed to make eg. react-hot-loader work. */
     depPipeline.push(through.obj(function(row, enc, next) {
-      row.source = "module.id = " + JSON.stringify(row.id) + "; " + row.source;
+      /* Prevent duplicate addition of the module.id prefix (which breaks hot-reload hashing) */
+      if (row.source.length < 12 || row.source.slice(0, 12) !== "module.id = ") {
+        row.source = "module.id = " + JSON.stringify(row.id) + "; " + row.source;
+      }
+
       next(null, row);
     }));
 


### PR DESCRIPTION
Title says it all. This fixes react-hot-loader, and probably other things that rely on `module.id` existing.