### PR TITLE
Add check for Origin & Host headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ and update url, so you generally don't need to worry about this option.
 instead of any buffers inside of it. This option may not be given by the
 command line.
 
+`disableHostCheck` disables Origin and Host header checking when connecting
+to the server via WebSockets. By default it is set to `false` to 3rd party
+websites from connecting to a local websocket and leaking source code. For
+more information see (NPM Advisory 726)[https://www.npmjs.com/advisories/726].
+
 If you don't use the default websocket update mode, then you'll need to
 manually tell browserify-hmr when it should check for and apply updates. You
 can use code like the following somewhere in your project to poll for updates:

--- a/inc/index.js
+++ b/inc/index.js
@@ -425,6 +425,9 @@ function main(
         isAcceptingMessages = true;
         queuedUpdateMessages = [];
       });
+      socket.on('error', function(err) {
+        console.error('[HMR] Websocket error: ' + err);
+      });
       socket.on('disconnect', function() {
         console.log('[HMR] Websocket connection lost.');
       });

--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ module.exports = function(bundle, opts) {
   var supportModes = (opts.supportModes && opts.supportModes._) || opts.supportModes || [];
   var noServe = boolOpt(readOpt(opts, 'noServe', null, false));
   var ignoreUnaccepted = boolOpt(readOpt(opts, 'ignoreUnaccepted', null, true));
+  var disableHostCheck = boolOpt(readOpt(opts, 'disableHostCheck', null, false));
 
   var basedir = opts.basedir !== undefined ? opts.basedir : process.cwd();
   var em = new EventEmitter();
@@ -159,6 +160,7 @@ module.exports = function(bundle, opts) {
     }).then(function(){
       return sendToServer({
         type: 'config',
+        disableHostCheck: disableHostCheck,
         hostname: hostname,
         port: port,
         tlsoptions: tlsoptions


### PR DESCRIPTION
closes #41, closes #43

This commit is an attempt to fix the isuse in NPM security advisory:

https://www.npmjs.com/advisories/726

Further reading:

- https://github.com/webpack/webpack-dev-server/commit/f18e5adf123221a1015be63e1ca2491ca45b8d10
- https://blog.cal1.cn/post/Sniffing%20Codes%20in%20Hot%20Module%20Reloading%20Messages